### PR TITLE
Update service hooks with useDeepMemo hook

### DIFF
--- a/.changeset/shaggy-trees-dress.md
+++ b/.changeset/shaggy-trees-dress.md
@@ -1,0 +1,6 @@
+---
+"@rsm-hcd/javascript-react": minor
+"todo": minor
+---
+
+Adds useDeepMemo hook and deep compare and replace object-utils

--- a/hcd-javascript.code-workspace
+++ b/hcd-javascript.code-workspace
@@ -1,0 +1,37 @@
+{
+    "folders": [
+        {
+            "path": "packages/javascript-core",
+        },
+        {
+            "path": "packages/javascript-react",
+        },
+        {
+            "path": "packages/javascript-testing",
+        },
+        {
+            "name": "root",
+            "path": ".",
+        },
+    ],
+    "settings": {
+        "files.associations": {
+            "*.tsx": "typescriptreact",
+            "*.css": "tailwindcss",
+            "*.scss": "tailwindcss",
+        },
+        "trailing-spaces.trimOnSave": true,
+        "typescript.tsdk": "./node_modules/typescript/lib",
+        "files.exclude": {
+            "**/.git": true,
+            "**/.svn": true,
+            "**/.hg": true,
+            "**/CVS": true,
+            "**/.DS_Store": true,
+            "**/Thumbs.db": true,
+            "packages/javascript-core": true,
+            "packages/javascript-react": true,
+            "packages/javascript-testing": true,
+        },
+    },
+}

--- a/packages/javascript-react/src/hooks/service-hooks/use-create.test.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-create.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
 import { Record } from "immutable";
 import { ServiceFactory } from "../../services/service-factory";
 import { setupMockApi } from "../../tests/setup-mock-api";

--- a/packages/javascript-react/src/hooks/service-hooks/use-delete.test.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-delete.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { ServiceFactory } from "../../services/service-factory";
 import { setupMockApi } from "../../tests/setup-mock-api";
 import { useDeleteService } from "./use-delete";

--- a/packages/javascript-react/src/hooks/service-hooks/use-get.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-get.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { CanceledError } from "axios";
 import { useAbortSignal } from "../use-abort-signal";
 import type { GetServiceWithSignal } from "../../types/get-service-type";
+import { useDeepMemo } from "../use-deep-memo";
 
 interface UseGetServiceHook<TRecord> {
     error?: Error;
@@ -25,7 +26,7 @@ export function useGetService<TRecord, TPathParams, TQueryParams>(
     getService: GetServiceWithSignal<TRecord, TPathParams, TQueryParams>,
     options: UseGetServiceHookOptions<TPathParams, TQueryParams>
 ): UseGetServiceHook<TRecord> {
-    const { autoLoad = true, pathParams, queryParams } = options;
+    const { autoLoad = true, pathParams, queryParams } = useDeepMemo(options);
 
     const signal = useAbortSignal();
     const [isLoading, setIsLoading] = useState(true);

--- a/packages/javascript-react/src/hooks/service-hooks/use-list.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-list.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { CanceledError } from "axios";
 import { useAbortSignal } from "../use-abort-signal";
 import type { ListServiceWithSignal } from "../../types/list-service-type";
+import { useDeepMemo } from "../use-deep-memo";
 
 interface UseListServiceHook<TRecord> {
     error?: Error;
@@ -24,8 +25,7 @@ export function useListService<TRecord = any, TQueryParams = {}>(
     listService: ListServiceWithSignal<TRecord, TQueryParams>,
     options: UseListServiceHookOptions<TQueryParams> = {}
 ): UseListServiceHook<TRecord> {
-    const { autoLoad = true, queryParams } = options;
-
+    const { autoLoad = true, queryParams } = useDeepMemo(options);
     const signal = useAbortSignal();
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<Error>();

--- a/packages/javascript-react/src/hooks/service-hooks/use-update.test.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-update.test.ts
@@ -23,8 +23,15 @@ class TestRecord extends Record<{ id: number; value: string }>({
     value: "",
 }) {}
 
+interface TestServiceUpdatePathParams {
+    id: number;
+}
+
 const TestService = {
-    update: ServiceFactory.update(TestRecord, resourceEndpoint),
+    update: ServiceFactory.update<TestRecord, TestServiceUpdatePathParams>(
+        TestRecord,
+        resourceEndpoint
+    ),
 };
 
 // #endregion Setup
@@ -113,6 +120,33 @@ describe("useCreateService", () => {
                     expect(result.current.error).toBeUndefined();
                     expect(result.current.updated).toEqual([]);
                 });
+            });
+        });
+
+        describe("rerender with the same path params", () => {
+            it("should be the same update method", () => {
+                // Arrange
+                const { result, rerender } = renderHook(
+                    ({ service, pathParams }) =>
+                        useUpdateService(service, pathParams),
+                    {
+                        initialProps: {
+                            service: TestService.update,
+                            pathParams: { id: 1 },
+                        },
+                    }
+                );
+
+                const preRerenderUpdate = result.current.update;
+
+                // Act
+                rerender({
+                    service: TestService.update,
+                    pathParams: { id: 1 },
+                });
+
+                // Assert
+                expect(preRerenderUpdate).toBe(result.current.update);
             });
         });
     });

--- a/packages/javascript-react/src/hooks/service-hooks/use-update.test.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-update.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
 import { Record } from "immutable";
 import { ServiceFactory } from "../../services/service-factory";
 import { setupMockApi } from "../../tests/setup-mock-api";

--- a/packages/javascript-react/src/hooks/service-hooks/use-update.ts
+++ b/packages/javascript-react/src/hooks/service-hooks/use-update.ts
@@ -3,6 +3,7 @@ import { CanceledError } from "axios";
 import type { RecordType } from "../../services/service-factory";
 import { useAbortSignal } from "../use-abort-signal";
 import type { UpdateServiceWithSignal } from "../../types/update-service-type";
+import { useDeepMemo } from "../use-deep-memo";
 
 interface UseUpdateServiceHook<TRecord> {
     error?: Error;
@@ -19,6 +20,7 @@ export function useUpdateService<TRecord extends RecordType, TPathParams>(
     const [isUpdating, setIsUpdating] = useState(false);
     const [error, setError] = useState<Error>();
     const [updated, setUpdated] = useState<TRecord[]>([]);
+    const memoizedPathParams = useDeepMemo(pathParams);
 
     const update = useCallback(
         (record: TRecord) => {
@@ -27,7 +29,7 @@ export function useUpdateService<TRecord extends RecordType, TPathParams>(
                     setIsUpdating(true);
                     const { resultObject } = await updateService(
                         record,
-                        pathParams,
+                        memoizedPathParams,
                         signal
                     );
 
@@ -63,7 +65,7 @@ export function useUpdateService<TRecord extends RecordType, TPathParams>(
                 }
             })();
         },
-        [pathParams, signal, updateService]
+        [memoizedPathParams, signal, updateService]
     );
 
     return {

--- a/packages/javascript-react/src/hooks/use-deep-memo.ts
+++ b/packages/javascript-react/src/hooks/use-deep-memo.ts
@@ -1,0 +1,11 @@
+import { useRef } from "react";
+import { deepReplace } from "../utilities/object-utils";
+
+/**
+ * Returns a memoized value that is deeply compared.
+ */
+export function useDeepMemo<TValue>(obj: TValue): TValue {
+    const ref = useRef<TValue>(obj);
+    ref.current = deepReplace(ref.current, obj);
+    return ref.current;
+}

--- a/packages/javascript-react/src/hooks/use-page-errors.test.tsx
+++ b/packages/javascript-react/src/hooks/use-page-errors.test.tsx
@@ -1,5 +1,6 @@
-import { renderHook, act } from "@testing-library/react-hooks";
-import { ResultRecord, ResultErrorRecord } from "@rsm-hcd/javascript-core";
+import { renderHook } from "@testing-library/react-hooks";
+import { act } from "react";
+import { ResultErrorRecord, ResultRecord } from "@rsm-hcd/javascript-core";
 import { waitFor } from "@testing-library/react";
 import { usePageErrors } from "./use-page-errors";
 

--- a/packages/javascript-react/src/hooks/use-sorted-alphabetically.test.tsx
+++ b/packages/javascript-react/src/hooks/use-sorted-alphabetically.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
-import React from "react";
-import { act } from "react-dom/test-utils";
+import React, { act } from "react";
 import { useSortedAlphabetically } from "./use-sorted-alphabetically";
 
 describe("useSortedAlphabetically", () => {
@@ -12,7 +11,7 @@ describe("useSortedAlphabetically", () => {
         const sortedList = ["A", "B", "C", "D"];
 
         const TestApp = () => {
-            const [values, setValues] = useSortedAlphabetically(
+            const [values] = useSortedAlphabetically(
                 unsortedList,
                 testSelector
             );

--- a/packages/javascript-react/src/hooks/use-window.test.tsx
+++ b/packages/javascript-react/src/hooks/use-window.test.tsx
@@ -1,8 +1,9 @@
-import { renderHook, act } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks";
+import { act } from "react";
 import { useWindow } from "./use-window";
 
-const DEFAULT_WIDTH: number = 1024;
-const DEFAULT_HEIGHT: number = 768;
+const DEFAULT_WIDTH = 1024;
+const DEFAULT_HEIGHT = 768;
 
 describe("useWindow", () => {
     beforeEach(() => {

--- a/packages/javascript-react/src/utilities/object-utils.test.ts
+++ b/packages/javascript-react/src/utilities/object-utils.test.ts
@@ -1,0 +1,77 @@
+import { deepReplace } from "./object-utils";
+
+describe("object-utils", () => {
+    describe("deepReplace", () => {
+        it("returns current value if new value is the same", () => {
+            // Arrange
+            const current = { a: 1, b: 2 };
+            const value = { a: 1, b: 2 };
+
+            // Act
+            const result = deepReplace(current, value);
+
+            // Assert
+            expect(result).toEqual(current);
+        });
+
+        it("returns new value if property values are different", () => {
+            // Arrange
+            const current = { a: 1, b: 2 };
+            const value = { a: 1, b: 3 };
+
+            // Act
+            const result = deepReplace(current, value);
+
+            // Assert
+            expect(result).not.toEqual(current);
+            expect(result.b).toEqual(value.b);
+            expect(result.a).toEqual(current.a);
+        });
+
+        it("returns current value if nested array values are the same", () => {
+            // Arrange
+            const current = { a: [1, 2, 3] };
+            const value = { a: [1, 2, 3] };
+
+            // Act
+            const result = deepReplace(current, value);
+
+            // Assert
+            expect(result).toEqual(current);
+        });
+
+        it("returns new value if nested property values are different", () => {
+            // Arrange
+            const current = {
+                a: 1,
+                b: {
+                    c: 2,
+                    d: 3,
+                },
+                e: {
+                    f: 4,
+                    g: 5,
+                },
+            };
+            const value = {
+                a: 1,
+                b: {
+                    c: 2,
+                    d: 4,
+                },
+                e: {
+                    f: 4,
+                    g: 5,
+                },
+            };
+
+            // Act
+            const result = deepReplace(current, value);
+
+            // Assert
+            expect(result).not.toEqual(current);
+            expect(result.b.d).toEqual(value.b.d);
+            expect(result.e).toEqual(current.e);
+        });
+    });
+});

--- a/packages/javascript-react/src/utilities/object-utils.test.ts
+++ b/packages/javascript-react/src/utilities/object-utils.test.ts
@@ -40,6 +40,30 @@ describe("object-utils", () => {
             expect(result).toEqual(current);
         });
 
+        it("returns current value if nested array objects are the same", () => {
+            // Arrange
+            const current = { a: [{ b: 1 }, { b: 1 }, { b: 3 }] };
+            const value = { a: [{ b: 1 }, { b: 1 }, { b: 3 }] };
+
+            // Act
+            const result = deepReplace(current, value);
+
+            // Assert
+            expect(result).toEqual(current);
+        });
+
+        it("returns new value if nested array objects are different", () => {
+            // Arrange
+            const current = { a: [{ b: 1 }, { b: 1 }, { b: 4 }] };
+            const value = { a: [{ b: 1 }, { b: 1 }, { b: 3 }] };
+
+            // Act
+            const result = deepReplace(current, value);
+
+            // Assert
+            expect(result).not.toEqual(current);
+        });
+
         it("returns new value if nested property values are different", () => {
             // Arrange
             const current = {

--- a/packages/javascript-react/src/utilities/object-utils.test.ts
+++ b/packages/javascript-react/src/utilities/object-utils.test.ts
@@ -97,5 +97,137 @@ describe("object-utils", () => {
             expect(result.b.d).toEqual(value.b.d);
             expect(result.e).toEqual(current.e);
         });
+
+        describe("arrays have the same values", () => {
+            it("returns current array", () => {
+                // Arrange
+                const current = [1, 2, 3];
+                const value = [1, 2, 3];
+
+                // Act
+                const result = deepReplace(current, value);
+
+                // Assert
+                expect(result).toEqual(current);
+            });
+        });
+
+        describe("arrays have different values", () => {
+            it("returns new array", () => {
+                // Arrange
+                const current = [1, 2, 3];
+                const value = [1, 2, 4];
+
+                // Act
+                const result = deepReplace(current, value);
+
+                // Assert
+                expect(result).toEqual(value);
+            });
+        });
+
+        describe("arrays have different lengths", () => {
+            it("returns new array", () => {
+                // Arrange
+                const current = [1, 2, 3];
+                const value = [1, 2];
+
+                // Act
+                const result = deepReplace(current, value);
+
+                // Assert
+                expect(result).toEqual(value);
+            });
+        });
+
+        describe("arrays have the same objects", () => {
+            it("returns current array", () => {
+                // Arrange
+                const current = [{ a: 1 }, { a: 2 }, { a: 3 }];
+                const value = [{ a: 1 }, { a: 2 }, { a: 3 }];
+
+                // Act
+                const result = deepReplace(current, value);
+
+                // Assert
+                expect(result).toEqual(current);
+            });
+        });
+
+        describe("arrays have different objects", () => {
+            it("returns new array", () => {
+                // Arrange
+                const current = [{ a: 1 }, { a: 2 }, { a: 3 }];
+                const value = [{ a: 1 }, { a: 2 }, { a: 4 }];
+
+                // Act
+                const result = deepReplace(current, value);
+
+                // Assert
+                expect(result).toEqual(value);
+            });
+        });
+
+        describe("primitive values", () => {
+            describe("current value is a string", () => {
+                describe("new value is a string", () => {
+                    describe("values are the same", () => {
+                        it("returns current string", () => {
+                            // Arrange
+                            const current = "current";
+                            const value = "current";
+
+                            // Act
+                            const result = deepReplace(current, value);
+
+                            // Assert
+                            expect(result).toEqual(current);
+                        });
+                    });
+
+                    describe("values are different", () => {
+                        it("returns new string", () => {
+                            // Arrange
+                            const current = "current";
+                            const value = "new";
+
+                            // Act
+                            const result = deepReplace(current, value);
+
+                            // Assert
+                            expect(result).toEqual(value);
+                        });
+                    });
+                });
+
+                describe("new value is a number", () => {
+                    it("returns new value", () => {
+                        // Arrange
+                        const current = "current";
+                        const value = 1;
+
+                        // Act
+                        const result = deepReplace<unknown>(current, value);
+
+                        // Assert
+                        expect(result).toEqual(value);
+                    });
+                });
+
+                describe("new value is an object", () => {
+                    it("returns new value", () => {
+                        // Arrange
+                        const current = "current";
+                        const value = { a: 1 };
+
+                        // Act
+                        const result = deepReplace<unknown>(current, value);
+
+                        // Assert
+                        expect(result).toEqual(value);
+                    });
+                });
+            });
+        });
     });
 });

--- a/packages/javascript-react/src/utilities/object-utils.ts
+++ b/packages/javascript-react/src/utilities/object-utils.ts
@@ -1,0 +1,128 @@
+/**
+ * Check if two objects are equal by deep comparison.
+ */
+export function isDeepCompareEqual<TValue>(
+    current: TValue,
+    value: TValue
+): boolean {
+    if (current === value || (current == null && value == null)) {
+        return true;
+    }
+
+    if (typeof current !== typeof value) {
+        return false;
+    }
+
+    if (Array.isArray(current) && Array.isArray(value)) {
+        if (current.length !== value.length) {
+            return false;
+        }
+
+        for (let i = 0; i < current.length; i++) {
+            if (!isDeepCompareEqual(current[i], value[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (
+        typeof current !== "object" ||
+        typeof value !== "object" ||
+        current == null ||
+        value == null
+    ) {
+        return current === value;
+    }
+
+    const currentKeys = Object.keys(current);
+    const optionsKeys = Object.keys(value);
+
+    if (currentKeys.length !== optionsKeys.length) {
+        return false;
+    }
+
+    // if keys are not equal, return false
+    if (currentKeys.some((key) => !optionsKeys.includes(key))) {
+        return false;
+    }
+
+    // recursively check if the objects are equal
+    for (const key in value) {
+        if (
+            typeof value[key] === "object" &&
+            !isDeepCompareEqual(current[key], value[key])
+        ) {
+            return false;
+        }
+
+        if (current[key] !== value[key]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Deeply replace the properties of an object with the properties of another object.
+ * If any values are replaced, it returns a new object.
+ */
+export function deepReplace<TValue>(current: TValue, value: TValue): TValue {
+    if (current === value || (current == null && value == null)) {
+        return current;
+    }
+
+    if (typeof current !== typeof value) {
+        return value;
+    }
+
+    if (Array.isArray(current) && Array.isArray(value)) {
+        if (current.length !== value.length) {
+            return value;
+        }
+
+        for (let i = 0; i < current.length; i++) {
+            if (!isDeepCompareEqual(current[i], value[i])) {
+                return value;
+            }
+        }
+
+        return current;
+    }
+
+    if (
+        typeof current !== "object" ||
+        typeof value !== "object" ||
+        current == null ||
+        value == null
+    ) {
+        return value;
+    }
+
+    const valueKeys = Object.keys(value);
+
+    let returnCurrent = true;
+    const next = { ...current };
+
+    // remove keys from current that are not in value
+    for (const key in next) {
+        if (!valueKeys.includes(key)) {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- this should be ok
+            delete next[key];
+            returnCurrent = false;
+        }
+    }
+
+    for (const key in value) {
+        const nextPropertyValue = deepReplace(current[key], value[key]);
+
+        if (nextPropertyValue !== current[key]) {
+            next[key] = nextPropertyValue;
+            returnCurrent = false;
+        }
+    }
+
+    return returnCurrent ? current : next;
+}

--- a/packages/javascript-react/src/utilities/object-utils.ts
+++ b/packages/javascript-react/src/utilities/object-utils.ts
@@ -1,3 +1,7 @@
+// -------------------------------------------------------------------------------------------------
+// #region Exports
+// -------------------------------------------------------------------------------------------------
+
 /**
  * Check if two objects are equal by deep comparison.
  */
@@ -5,37 +9,59 @@ export function isDeepCompareEqual<TValue>(
     current: TValue,
     value: TValue
 ): boolean {
-    if (current === value || (current == null && value == null)) {
+    if (isSame(current, value)) {
         return true;
     }
 
-    if (typeof current !== typeof value) {
+    if (isTypeMismatch(current, value)) {
         return false;
     }
 
     if (Array.isArray(current) && Array.isArray(value)) {
-        if (current.length !== value.length) {
-            return false;
-        }
-
-        for (let i = 0; i < current.length; i++) {
-            if (!isDeepCompareEqual(current[i], value[i])) {
-                return false;
-            }
-        }
-
-        return true;
+        return deepCompareArray(current, value);
     }
 
-    if (
-        typeof current !== "object" ||
-        typeof value !== "object" ||
-        current == null ||
-        value == null
-    ) {
+    if (!isObject(current) || !isObject(value)) {
         return current === value;
     }
 
+    return deepCompareObject(current, value);
+}
+
+/**
+ * Deeply replace the properties of an object with the properties of another object.
+ * If any values are replaced, it returns a new object.
+ */
+export function deepReplace<TValue>(current: TValue, value: TValue): TValue {
+    if (isSame(current, value)) {
+        return current;
+    }
+
+    if (isTypeMismatch(current, value)) {
+        return value;
+    }
+
+    if (Array.isArray(current) && Array.isArray(value)) {
+        return deepReplaceArray(current, value);
+    }
+
+    if (!isObject(current) || !isObject(value)) {
+        return value;
+    }
+
+    return deepReplaceObject(current, value);
+}
+
+// #endregion Exports
+
+// -------------------------------------------------------------------------------------------------
+// #region Private Methods
+// -------------------------------------------------------------------------------------------------
+
+function deepCompareObject<TValue extends object>(
+    current: TValue,
+    value: TValue
+): boolean {
     const currentKeys = Object.keys(current);
     const optionsKeys = Object.keys(value);
 
@@ -51,7 +77,7 @@ export function isDeepCompareEqual<TValue>(
     // recursively check if the objects are equal
     for (const key in value) {
         if (
-            typeof value[key] === "object" &&
+            isObject(value[key]) &&
             !isDeepCompareEqual(current[key], value[key])
         ) {
             return false;
@@ -65,42 +91,27 @@ export function isDeepCompareEqual<TValue>(
     return true;
 }
 
-/**
- * Deeply replace the properties of an object with the properties of another object.
- * If any values are replaced, it returns a new object.
- */
-export function deepReplace<TValue>(current: TValue, value: TValue): TValue {
-    if (current === value || (current == null && value == null)) {
-        return current;
+function deepCompareArray<TValue extends unknown[]>(
+    current: TValue,
+    value: TValue
+): boolean {
+    if (current.length !== value.length) {
+        return false;
     }
 
-    if (typeof current !== typeof value) {
-        return value;
-    }
-
-    if (Array.isArray(current) && Array.isArray(value)) {
-        if (current.length !== value.length) {
-            return value;
+    for (let i = 0; i < current.length; i++) {
+        if (!isDeepCompareEqual(current[i], value[i])) {
+            return false;
         }
-
-        for (let i = 0; i < current.length; i++) {
-            if (!isDeepCompareEqual(current[i], value[i])) {
-                return value;
-            }
-        }
-
-        return current;
     }
 
-    if (
-        typeof current !== "object" ||
-        typeof value !== "object" ||
-        current == null ||
-        value == null
-    ) {
-        return value;
-    }
+    return true;
+}
 
+function deepReplaceObject<TValue extends object>(
+    current: TValue,
+    value: TValue
+): TValue {
     const valueKeys = Object.keys(value);
 
     let returnCurrent = true;
@@ -126,3 +137,34 @@ export function deepReplace<TValue>(current: TValue, value: TValue): TValue {
 
     return returnCurrent ? current : next;
 }
+
+function deepReplaceArray<TValue extends unknown[]>(
+    current: TValue,
+    value: TValue
+): TValue {
+    if (current.length !== value.length) {
+        return value;
+    }
+
+    for (let i = 0; i < current.length; i++) {
+        if (!isDeepCompareEqual(current[i], value[i])) {
+            return value;
+        }
+    }
+
+    return current;
+}
+
+function isSame<TValue>(current: TValue, value: TValue) {
+    return current === value || (current == null && value == null);
+}
+
+function isTypeMismatch<TValue>(current: TValue, value: TValue) {
+    return typeof current !== typeof value;
+}
+
+function isObject(value: unknown): value is object {
+    return value != null && typeof value === "object";
+}
+
+// #endregion Private Methods

--- a/samples/todo/src/App.tsx
+++ b/samples/todo/src/App.tsx
@@ -1,8 +1,8 @@
 import {
-    useListService,
     useCreateService,
-    useUpdateService,
     useDeleteService,
+    useListService,
+    useUpdateService,
 } from "@rsm-hcd/javascript-react";
 import { TodoService } from "./services/todo-service";
 import { TodoRecord } from "./models/todo";
@@ -12,7 +12,11 @@ import { useResultsMerge } from "./hooks/use-results-merge";
 
 function App() {
     const inputRef = useRef<HTMLInputElement>(null);
-    const { refresh, results } = useListService(TodoService.list);
+    const { refresh, results } = useListService(TodoService.list, {
+        queryParams: {
+            completed: true,
+        },
+    });
     const { create, created } = useCreateService(TodoService.create);
     const { update, updated } = useUpdateService(TodoService.update);
     const { delete: remove, deleted } = useDeleteService(TodoService.delete);
@@ -43,7 +47,8 @@ function App() {
                     <button
                         type="button"
                         onClick={refresh}
-                        className="px-4 py-2 border border-black rounded-md bg-slate-100 text-slate-950">
+                        className="px-4 py-2 border border-black rounded-md bg-slate-100 text-slate-950"
+                    >
                         Refresh
                     </button>
                 </div>
@@ -56,7 +61,8 @@ function App() {
             <div className="container flex-grow mx-auto mt-4">
                 <form
                     className="flex flex-row gap-2"
-                    onSubmit={handleFormSubmission}>
+                    onSubmit={handleFormSubmission}
+                >
                     <input
                         ref={inputRef}
                         className="flex-grow px-4 py-2 border border-black rounded-md"
@@ -65,7 +71,8 @@ function App() {
                     />
                     <button
                         type="submit"
-                        className="px-4 py-2 border border-black rounded-md bg-slate-100">
+                        className="px-4 py-2 border border-black rounded-md bg-slate-100"
+                    >
                         +
                     </button>
                 </form>
@@ -89,7 +96,8 @@ function App() {
                                 </p>
                             </th>
                             <th className="p-4 border-b border-blue-gray-100 bg-blue-gray-50">
-                                <p className="block font-sans text-sm antialiased font-normal leading-none text-blue-gray-900 opacity-70"></p>
+                                <p className="block font-sans text-sm antialiased font-normal leading-none text-blue-gray-900 opacity-70">
+                                </p>
                             </th>
                         </tr>
                     </thead>
@@ -97,7 +105,8 @@ function App() {
                         {fullResults.map((todo) => (
                             <tr
                                 key={todo.id}
-                                className="even:bg-blue-gray-50/50">
+                                className="even:bg-blue-gray-50/50"
+                            >
                                 <td className="p-4">
                                     <p className="block font-sans text-sm antialiased font-normal leading-normal text-blue-gray-900">
                                         {todo.id}
@@ -117,16 +126,18 @@ function App() {
                                     <div className="flex flex-row gap-2">
                                         <button
                                             onClick={handleToggleTodoCompletion(
-                                                todo
+                                                todo,
                                             )}
-                                            className="inline-block px-2 font-sans text-sm antialiased font-medium leading-normal border rounded hover:bg-slate-200 border-slate-600 text-blue-gray-900">
+                                            className="inline-block px-2 font-sans text-sm antialiased font-medium leading-normal border rounded hover:bg-slate-200 border-slate-600 text-blue-gray-900"
+                                        >
                                             {todo.completed
                                                 ? "Reopen"
                                                 : "Complete"}
                                         </button>
                                         <button
                                             onClick={handleRemoveTodo(todo)}
-                                            className="inline-block px-2 font-sans text-sm antialiased font-medium leading-normal border rounded hover:bg-slate-200 border-slate-600 text-blue-gray-900">
+                                            className="inline-block px-2 font-sans text-sm antialiased font-medium leading-normal border rounded hover:bg-slate-200 border-slate-600 text-blue-gray-900"
+                                        >
                                             Remove
                                         </button>
                                     </div>

--- a/samples/todo/src/services/todo-service.ts
+++ b/samples/todo/src/services/todo-service.ts
@@ -1,8 +1,15 @@
 import { ServiceFactory } from "@rsm-hcd/javascript-react";
 import { TodoRecord } from "../models/todo";
 
+interface TodoListQueryParams {
+    completed?: boolean;
+}
+
 export const TodoService = {
-    list: ServiceFactory.list(TodoRecord, "api/todos"),
+    list: ServiceFactory.list<TodoRecord, TodoListQueryParams>(
+        TodoRecord,
+        "api/todos",
+    ),
     create: ServiceFactory.create(TodoRecord, "api/todos"),
     update: ServiceFactory.update(TodoRecord, "api/todos/:id"),
     get: ServiceFactory.get(TodoRecord, "api/todos/:id"),


### PR DESCRIPTION
Fixes: #153 

feat: add deep compare and replace methods
feat: add useDeepMemo hook (uses deepCompare and deepReplace methods)
fix: update `useListService` and `useGetService` to utilize `useDeepMemo` hook

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [x] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
